### PR TITLE
Fix init command regression

### DIFF
--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -3,9 +3,8 @@ const path = require('path');
 const rimraf = require('rimraf');
 const { linkUserDeps, unlinkUserDeps } = require('../utils/index');
 
-const ribbitConfig = require(path.join(process.env.PWD, '/ribbit.config.js'));
-
 function build() {
+  const ribbitConfig = require(path.join(process.env.PWD, '/ribbit.config.js'));
   linkUserDeps(ribbitConfig.dependencies, process.env.PWD);
   const child = exec(
     `npm run start-server ${process.env.PWD}`,


### PR DESCRIPTION
# What?
Resolves the error message bug for config when running `ribbit init`