### PR TITLE
HTML Templating

### DIFF
--- a/lib/cli/commands/init.js
+++ b/lib/cli/commands/init.js
@@ -28,6 +28,7 @@ async function init({ css = 'internal', view = 'html', images } = {}) {
 
   const completeBuild = await buildConfig({
     ...promptAnswers,
+    resolve_templates: 'src/templates',
     rules: {
       css,
       view,
@@ -98,11 +99,13 @@ async function buildRoutes({ appRoot }) {
         {
           route: '/',
           assetName: 'index',
-          component: './ExampleComponent.js'
+          component: './ExampleComponent.js',
+          template: ''
         },
         {
           route: '/about/contact',
-          component: './ExampleContactComponent.js'
+          component: './ExampleContactComponent.js',
+          template: ''
         }
       ],
       null,

--- a/server/middleware/executeStream.js
+++ b/server/middleware/executeStream.js
@@ -10,16 +10,15 @@ const executeStream = (req, res, next) => {
   } = res.locals;
 
   const CompiledApp = require(`../../dist/App.js`).default;
-  // console.log('COMPILED APP_____', CompiledApp);
 
-  //  user exports their store from wherever they created it
+  // user exports their store from wherever they created it
   // user must give the path to their store file
 
   // serialize w/ redux plugin
   // during execution of jsxCompose, redux requires a store be passed in
+
   const context = {};
-  let componentRoute = req.url;
-  if (componentRoute === '/') componentRoute = routesCliCommand.homeComponent;
+  const componentRoute = req.url;
 
   const jsx = (
     // wrap static router in redux Provider in order to user redux state

--- a/server/middleware/renderHTML.js
+++ b/server/middleware/renderHTML.js
@@ -14,11 +14,14 @@ function htmlTemplate(req, res, next) {
   const templateDir = ribbitConfig.resolve_templates;
   const routeObj = ribbitRoutes.filter(routeObject => routeObject.route===req.url)
   const templateFile = routeObj[0].template;
-  console.log("****ribbitRoutes: ", ribbitRoutes);
-  console.log("templateDir: ", templateDir);
-  console.log("routeObj: ", routeObj);
-  console.log("templateFile: ", templateFile);
-
+  // console.log("****ribbitRoutes: ", ribbitRoutes);
+  // console.log("templateDir: ", templateDir);
+  // console.log("routeObj: ", routeObj);
+  // console.log("templateFile: ", templateFile);
+  const htmlTemplatePath = path.join(appParentDirectory, `${templateDir + '/' + templateFile}`)
+  // console.log("htmlTemplatePath: ", htmlTemplatePath);
+  let html = fs.readFileSync(htmlTemplatePath).toString('utf8');
+  // console.log("htmlTemplateContents: ", html);
   const reactStream = renderToNodeStream(jsx);
 
   let reactDom = '';
@@ -32,25 +35,28 @@ function htmlTemplate(req, res, next) {
       path.resolve(__dirname, '../../dist/styles.min.css'),
       'utf8',
       (err, data) => {
-        const criticalCSS = purifyCSS(reactDom, data);
+        const criticalCSS = `<style>${purifyCSS(reactDom, data)}</style>`;
         //
-        const html = `
-          <!DOCTYPE html>
-          <html>
-          <head>
-          <meta charset="utf-8">
-          <title>React SSR</title>
-          <style>${criticalCSS}</style>
-          </head>
-          <body>
-          <div id="app">${reactDom}</div>
-          <script>
-          window.RIBBIT_PRELOADED_STATE = ${JSON.stringify(preLoadedState).replace(/</g)}
-          </script>
-          <script src="${ribbitConfig.bundleRoot}.js"></script>
-          </body>
-          </html>
-          `;
+        console.log("REACTDOM LINE40", reactDom);
+        html = html.replace('<!-- ribbit-css -->', criticalCSS);
+        html = html.replace('<!-- ribbit-bundle -->', reactDom);
+        // const html = `
+        //   <!DOCTYPE html>
+        //   <html>
+        //   <head>
+        //   <meta charset="utf-8">
+        //   <title>React SSR</title>
+        //   <style>${criticalCSS}</style>
+        //   </head>
+        //   <body>
+        //   <div id="app">${reactDom}</div>
+        //   <script>
+        //   window.RIBBIT_PRELOADED_STATE = ${JSON.stringify(preLoadedState).replace(/</g)}
+        //   </script>
+        //   <script src="${ribbitConfig.bundleRoot}.js"></script>
+        //   </body>
+        //   </html>
+        //   `;
         res.locals = {
           ...res.locals,
           html

--- a/server/middleware/renderHTML.js
+++ b/server/middleware/renderHTML.js
@@ -6,9 +6,18 @@ const purifyCSS = require('purify-css');
 
 const decoder = new StringDecoder('utf8');
 
+const ribbitRoutes = require('../consts/globals').USER_RIBBIT_ROUTES;
+
 function htmlTemplate(req, res, next) {
   const { appParentDirectory, jsx, preLoadedState } = res.locals;
   const ribbitConfig = require(path.join(appParentDirectory, '/ribbit.config.js'));
+  const templateDir = ribbitConfig.resolve_templates;
+  const routeObj = ribbitRoutes.filter(routeObject => routeObject.route===req.url)
+  const templateFile = routeObj[0].template;
+  console.log("****ribbitRoutes: ", ribbitRoutes);
+  console.log("templateDir: ", templateDir);
+  console.log("routeObj: ", routeObj);
+  console.log("templateFile: ", templateFile);
 
   const reactStream = renderToNodeStream(jsx);
 
@@ -24,6 +33,7 @@ function htmlTemplate(req, res, next) {
       'utf8',
       (err, data) => {
         const criticalCSS = purifyCSS(reactDom, data);
+        //
         const html = `
           <!DOCTYPE html>
           <html>

--- a/server/middleware/serializeData.js
+++ b/server/middleware/serializeData.js
@@ -3,7 +3,10 @@ const { generateClientData } = require('../modules/serializing');
 
 const serializeData = (req, res, next) => {
   // pull state out of store
+  const { currentRoute } = res.locals;
   const { store, window } = require(`../../dist/App.js`); // should come from serialize object
+  console.log('REQ URL_____', req.url);
+  console.log('Current Route_____', currentRoute);
   const preLoadedState = store.getState(); // move into serialize function
 
   // todo: set-up genPhasePlugins('serializing', 'clientData');

--- a/server/middleware/serializeData.js
+++ b/server/middleware/serializeData.js
@@ -5,8 +5,6 @@ const serializeData = (req, res, next) => {
   // pull state out of store
   const { currentRoute } = res.locals;
   const { store, window } = require(`../../dist/App.js`); // should come from serialize object
-  console.log('REQ URL_____', req.url);
-  console.log('Current Route_____', currentRoute);
   const preLoadedState = store.getState(); // move into serialize function
 
   // todo: set-up genPhasePlugins('serializing', 'clientData');

--- a/server/middleware/toDoList.js
+++ b/server/middleware/toDoList.js
@@ -1,6 +1,0 @@
-- [x] Get template directory from ribbit config
-- [x] Get template file name for route from ribbit routes
-- [x] Get route name from req.url
-- [] Import template file as a string and save it to a variable
-- [] We need to import exported context object from each page component
-	(directory name from appRoot in ribbit config, file name from ribbit routes)

--- a/server/middleware/toDoList.js
+++ b/server/middleware/toDoList.js
@@ -1,0 +1,6 @@
+- [x] Get template directory from ribbit config
+- [x] Get template file name for route from ribbit routes
+- [x] Get route name from req.url
+- [] Import template file as a string and save it to a variable
+- [] We need to import exported context object from each page component
+	(directory name from appRoot in ribbit config, file name from ribbit routes)

--- a/server/modules/rendering/generateTemplate.js
+++ b/server/modules/rendering/generateTemplate.js
@@ -1,0 +1,22 @@
+const generateDefaultTemplate = (css, DOM, state, bundle) => `
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ title }}</title>
+{{ meta }}
+<style>${css}</style>
+</head>
+<body>
+<div id="app"><!--ribbit-output--></div>
+<!--ribbit-scripts-->
+</body>
+</html>
+`;
+
+const generateTemplate = () => {};
+
+module.exports = {
+  generateDefaultTemplate,
+  generateTemplate
+};

--- a/server/modules/rendering/generateTemplate.js
+++ b/server/modules/rendering/generateTemplate.js
@@ -1,14 +1,12 @@
-const generateDefaultTemplate = (css, DOM, state, bundle) => `
+const generateDefaultTemplate = () => `
 <!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
-<title>{{ title }}</title>
-{{ meta }}
-<style>${css}</style>
+<!-- ribbit-css -->
 </head>
 <body>
-<div id="app"><!--ribbit-output--></div>
+<div id="app"><!-- ribbit-bundle --></div>
 <!--ribbit-scripts-->
 </body>
 </html>

--- a/server/modules/rendering/index.js
+++ b/server/modules/rendering/index.js
@@ -1,6 +1,9 @@
 const writeStaticFiles = require('./writeStaticFiles');
+const { generateDefaultTemplate, generateTemplate } = require('./generateTemplate');
 
 module.exports = {
+  generateDefaultTemplate,
+  generateTemplate,
   renderPort: 5000,
   writeStaticFiles
 };

--- a/server/server.js
+++ b/server/server.js
@@ -55,6 +55,10 @@ app.get(
   routesData.routes,
   (req, res, next) => {
     res.locals = {
+      currentRoute: routes.reduce((acc, route) => {
+        if (route.route === req.url) return route;
+        return acc;
+      }, ''),
       routesCliCommand,
       appParentDirectory: USER_PROJECT_DIRECTORY,
       routeAndAssetName: routesData.assetRouteMap

--- a/server/server.js
+++ b/server/server.js
@@ -55,10 +55,6 @@ app.get(
   routesData.routes,
   (req, res, next) => {
     res.locals = {
-      currentRoute: routes.reduce((acc, route) => {
-        if (route.route === req.url) return route;
-        return acc;
-      }, ''),
       routesCliCommand,
       appParentDirectory: USER_PROJECT_DIRECTORY,
       routeAndAssetName: routesData.assetRouteMap

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,20 @@
+
+  const ExtractTextPlugin = require("extract-text-webpack-plugin");
+  const extractCSS = new ExtractTextPlugin("styles.min.css");
+  module.exports = {
+    output: {
+      filename: './[name].js',
+      libraryTarget: 'commonjs'
+    },module: { rules:
+   [ { test: /\.js$/,
+       exclude: [ /node_modules/ ],
+       use:
+        { loader: 'babel-loader',
+          options: { presets: [ '@babel/preset-env', '@babel/preset-react' ] } } },
+     { test: /\.css$/,
+       use:
+        [ { loader:
+             '/Users/brianhon/github/Projects/ribbit/node_modules/extract-text-webpack-plugin/dist/loader.js',
+            options: { id: 1, omit: 0, remove: true } },
+          { loader: 'css-loader' },
+          { loader: 'postcss-loader' } ] } ] },plugins:[extractCSS]}


### PR DESCRIPTION
### **What?**

Ribbit can now use user-provided HTML templates for generating static markup files.

### **Why?**

This allows the user to have a custom HTML template per page, meaning they can choose the meta-tags, the location for the insertion of generated markup, and any additional scripts they might want to add to the page.

### **How?**

For the user:
- Create a template folder containing a bunch of template (HTML) files.
- The template folder must be declared in ribbit.config.js in the resolve_templates property.
- The actual template file name must be declared per route in ribbit.routes.json, in the template property. - If a template file is not declared, a default internal template will be used instead.


The following strings must to be included in the template file:
- <!-- ribbit-bundle --> (The location where the generated markup will be injected)
- <!-- ribbit-scripts -->  (The location where scripts will be injected: currently just the bundle file)
- <!-- ribbit-css --> (Optional: if using the CSS plugin)

Any additional properties can be added inside of double curly bracket notation, i.e. {{title}}, {{meta}}  etc. 

These will be interpolated with corresponding values in an exported context object from within the client-side component mapped to said route. For example, if pageOne.js has the following code:

`
export const context = {
  title: "Page #1",
};
`

And the template file for it has the following:

`<title>{{title}}</title>`

The {{title}} in the template will be replaced with the value in the exported context object.

### **How to test?**

- Clone/checkout the 'html-templating' branch of both ribbit and the demo-app.
- Run ribbit build from inside the demo app to see that the generated HTML files are using the specified HTML templates.