### PR TITLE
Set up jsxCompose to receive additional react components.

### DIFF
--- a/server/modules/presets/react/jsxCompose.js
+++ b/server/modules/presets/react/jsxCompose.js
@@ -1,13 +1,17 @@
 import React from 'react';
 
 function jsxCompose(plugins, App, config) {
-  const { plugin } = require('@ribbit/react-router');
-
   if (!plugins.length) {
     return <App />;
   }
 
-  return plugin({ App, config });
+  return plugins.reduce((acc, cur, idx, arr) => {
+    const currentApp = cur({ App: acc, config });
+    if (idx === arr.length - 1) {
+      return currentApp;
+    }
+    return () => currentApp;
+  }, <App />);
 }
 
 module.exports = jsxCompose;

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const composeFns = (f, g) => (arg, config) => f(g(arg, config), config);
+const composeFns = (f, g) => arg => f(g(arg));
 
 const getPlugins = ({ pluginsArr, USER_PROJECT_DIRECTORY }) =>
   pluginsArr.reduce((acc, currPlugin) => {


### PR DESCRIPTION
# What?
Sets up JSXCompose to be to receive additional React Component plugins.

![screen recording 2019-02-16 at 09 58 pm](https://user-images.githubusercontent.com/42384593/52907785-87d4be00-3236-11e9-834f-2092a20901c6.gif)
![screen recording 2019-02-16 at 09 58 pm-1](https://user-images.githubusercontent.com/42384593/52907788-8c997200-3236-11e9-9084-a6ecbe9e8af6.gif)

# Why?
JSXCompose needs to be able to accept as many react components as a user can provide.
